### PR TITLE
Fix dependabot settings for group version update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,10 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>

ref: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/